### PR TITLE
Versão do sshcommand e documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 Esse repositório por hora servirá de espaço para organização do time de infra para o projeto Dados Abertos De Feira.
 
 Aqui teremos a lista de tarefas e qualquer documento necessário pra ajudar pessoas a começarem a ajudar.
+
+# Como executar
+
+Você precisa ter o ansible instalado em sua máquina ou executá-lo em um contêiner docker.
+
+Primeiro é necessário instalar as roles necessárias com o comando
+
+```
+ansible-galaxy install -r requirements.yml
+```
+
+Depois, crie um inventário para a máquina de teste. No repositório há um inventário de exemplo em *hosts.example*. Recomenda-se utilizar uma máquina com Ubuntu 18.04.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Aqui teremos a lista de tarefas e qualquer documento necessário pra ajudar pess
 
 Você precisa ter o ansible instalado em sua máquina ou executá-lo em um contêiner docker.
 
-Primeiro é necessário instalar as roles necessárias com o comando
+Primeiro é necessário instalar as roles necessárias com o comando:
 
 ```
 ansible-galaxy install -r requirements.yml

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,6 +8,7 @@
     # need some swap to ensure you don't run out of RAM during deploys
     #swap_file_size_mb: '2048'
     dokku_version: 0.22.3
+    sshcommand_version: 0.12.0
     #dokku_users:
     #  - name: gomex
     #    username: gomex


### PR DESCRIPTION
A versão configurada do dokku pede uma versão do sshcommand igual ou superior a 0.12.0.
Também adicionei documentação básica de como executar o projeto indicando o sistema operacional utilizado.