### PR TITLE
Subir em máquinas com CGroup não híbrido

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,7 @@
+FROM geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest
+
+ADD https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/v1.5.4505/files/docker/systemctl3.py /bin/systemctl
+
+ADD https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/v1.5.4505/files/docker/journalctl3.py /bin/journalctl
+
+RUN chmod a+x /bin/systemctl /bin/journalctl && cp /bin/systemctl /lib/systemd/systemd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,14 +9,9 @@ driver:
   name: docker
 platforms:
   - name: ubuntu-18.04
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    image: "ubuntu1804"
     published_ports:
       - 80:80/tcp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
 provisioner:
   name: ansible
   playbooks:


### PR DESCRIPTION
A imagem utilizada apresenta problemas ao utilizar o systemd caso a máquina hospedeira tenha uma hierarquia de CGroup unificada. Adicionei modificações para que a imagem seja customizada com [docker-systemctl-replacement](https://github.com/gdraheim/docker-systemctl-replacement) e permita utilizar funcionalidades do systemd independente do hospedeiro.