### PR TITLE
Adicionando logtype no newrelic logging

### DIFF
--- a/config_files/logging.yml
+++ b/config_files/logging.yml
@@ -11,6 +11,8 @@ logs:
 
   - name: docker-logs
     file: /var/lib/docker/containers/*/*.log
+    attributes:
+      logtype: docker
 
   - name: nginx-access-logs
     file: /var/log/nginx/access.log*


### PR DESCRIPTION
Precisamos de uma categoria para o log do docker.